### PR TITLE
Ensure dropdown menu displays dark text and overlays on wider screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,11 +46,11 @@
     <div class="topbar" role="navigation" aria-label="Primary">
         <div class="topbar-inner">
             <a class="brand-mini" href="/" aria-label="Miss Kim's Dance Class Home">Miss Kim’s</a>
-            <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">Menu</button>
+            <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-menu">Menu</button>
             <ul id="primary-menu" class="menu" role="menubar">
                 <li role="none"><a role="menuitem" href="/">Home</a></li>
                 <li role="none" class="has-dropdown">
-                    <button class="dropdown-toggle" aria-haspopup="true" aria-expanded="false">Other Dance &amp; Movement</button>
+                    <button class="dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">Other Dance &amp; Movement <span class="chevron" aria-hidden="true">▾</span></button>
                     <ul class="dropdown" role="menu" aria-label="Other Dance & Movement">
                         <li role="none"><a role="menuitem" href="/pom-poms-classes">Pom-Poms</a></li>
                         <li role="none"><a role="menuitem" href="/contemporary-dance-classes">Contemporary Dance</a></li>
@@ -287,18 +287,18 @@
                 }, { passive: true });
             }
 
-            const isDesktop = () => matchMedia("(min-width: 921px)").matches;
+            const isDesktop = () => matchMedia("(min-width: 720px)").matches;
 
             // Dropdowns
+            let ddCounter = 0;
             const parents = $$(".has-dropdown");
             parents.forEach(parent => {
                 const btn = $(".dropdown-toggle", parent);
                 const panel = $(".dropdown", parent);
                 if (!btn || !panel) return;
                 // give each panel an id and point the button at it
-                const uid = (() => { let i = 0; return () => `dd-${++i}`; })();
-                const id = panel.id || (panel.id = uid());
-                btn.setAttribute('aria-controls', id);
+                if (!panel.id) panel.id = `dd-${++ddCounter}`;
+                btn.setAttribute("aria-controls", panel.id);
 
                 let hideTimer;
 

--- a/styles.css
+++ b/styles.css
@@ -196,17 +196,6 @@ p { /* paragraph styles */
         margin-left: 0 /* reset right push */
     }
 
-    .has-dropdown .dropdown {
-        position: static; /* normal flow on mobile */
-        box-shadow: none; /* remove elevation */
-        border: 0; /* remove border */
-        background: transparent; /* transparent */
-        padding: 0 /* no extra padding */
-    }
-
-        .has-dropdown .dropdown a {
-            padding: .45rem 0 /* tighter vertical spacing */
-        }
 }
 /* ===================== Header ===================== */
 
@@ -855,92 +844,6 @@ p { /* paragraph styles */
 .hero-background.tap { /* hero variant for Tap page */
     background: url('/images/tap1.JPG') center/cover no-repeat; /* tap image */
 }
-/* Dropdown: smooth open/close and no hover gap */
-.has-dropdown { /* dropdown wrapper */
-    position: relative; /* anchor for absolute dropdown */
-}
-
-    .has-dropdown > .dropdown { /* dropdown panel */
-        position: absolute; /* position under trigger */
-        left: 0; /* align left */
-        top: 100%; /* sit flush under button */
-        margin-top: .4rem; /* visual spacing, not a real gap */
-        min-width: 250px; /* minimum width */
-        background: #231c2e; /* dark panel bg */
-        border: 1px solid rgba(255,255,255,.1); /* subtle border */
-        border-radius: .75rem; /* rounded panel */
-        box-shadow: 0 18px 40px rgba(0,0,0,.35); /* deep shadow */
-        padding: .5rem; /* inner padding */
-        z-index: 1000; /* above header */
-        /* transition-friendly hide/show */
-        opacity: 0; /* hidden by default */
-        visibility: hidden; /* not visible */
-        transform: translateY(4px); /* slight offset for animation */
-        pointer-events: none; /* ignore clicks while hidden */
-        transition: opacity .18s ease, transform .18s ease, visibility 0s linear .18s; /* animate open/close */
-    }
-
-        /* Hover bridge to prevent "gap" when moving pointer down */
-        .has-dropdown > .dropdown::before { /* invisible bridge area */
-            content: ""; /* pseudo-element */
-            position: absolute; /* position above panel */
-            left: 0; /* stretch full width */
-            right: 0; /* stretch full width */
-            top: -10px; /* sit above to catch hover */
-            height: 10px; /* invisible buffer */
-        }
-
-    .has-dropdown.open > .dropdown { /* visible/open state */
-        opacity: 1; /* fully visible */
-        visibility: visible; /* visible */
-        transform: translateY(0); /* reset offset */
-        pointer-events: auto; /* clickable */
-        transition-delay: 0s; /* show immediately */
-    }
-
-    .has-dropdown .dropdown a { /* dropdown links */
-        display: block; /* full width */
-        padding: .55rem .75rem; /* spacing */
-        border-radius: .5rem; /* rounded */
-        white-space: nowrap; /* keep on one line */
-        color: #fff; /* white text */
-        text-decoration: none; /* no underline */
-    }
-
-        .has-dropdown .dropdown a:hover { /* hover state */
-            background: rgba(255,255,255,.08); /* highlight on hover */
-        }
-
-/* Mobile: make panel inline and visible when parent .open */
-@media (max-width: 920px) { /* dropdown behavior on mobile */
-    .menu {
-        display: none; /* hidden by default (toggled elsewhere) */
-    }
-
-        .menu.open {
-            display: flex; /* show menu */
-            flex-direction: column; /* vertical layout */
-            align-items: flex-start; /* left align */
-            width: 100%; /* full width */
-        }
-
-    .has-dropdown > .dropdown {
-        position: static; /* inline in flow */
-        margin-top: 0; /* remove gap */
-        background: transparent; /* no panel bg */
-        border: 0; /* no border */
-        box-shadow: none; /* no shadow */
-        opacity: 1; /* always visible */
-        visibility: visible; /* visible */
-        transform: none; /* no transform */
-        pointer-events: auto; /* interactive */
-        padding: 0; /* no padding */
-    }
-
-    .has-dropdown .dropdown a {
-        padding: .45rem 0; /* tighter link spacing */
-    }
-}
 /* ========= Mobile polish pack (append at end) ========= */
 :root{
   --brand:#5f35b0; --ink:#111; --pad:16px; --radius:16px;
@@ -975,13 +878,6 @@ img{max-width:100%;height:auto;border-radius:12px;display:block}
 }
 .menu a:hover,.menu .dropdown-toggle:hover{background:#f0f0fa}
 
-/* Dropdowns: inline list on mobile; popover on desktop (your JS handles open) */
-.has-dropdown .dropdown{
-  list-style:none;margin:6px 0 0;padding:8px;border-left:3px solid var(--brand);
-  display:none;flex-direction:column;gap:6px;background:#fff;border-radius:8px;
-}
-.has-dropdown.open .dropdown{display:flex}
-.dropdown a{background:#fff;border:1px dashed #e8e8f7}
 
 /* Hero */
 .hero{border-radius:0 0 24px 24px;overflow:hidden}
@@ -1045,10 +941,6 @@ img{max-width:100%;height:auto;border-radius:12px;display:block}
   .menu a:hover,.menu .dropdown-toggle:hover{background:#f5f3ff}
   .menu-right{margin-left:auto}
   .has-dropdown{position:relative}
-  .has-dropdown .dropdown{
-    position:absolute;left:0;top:calc(100% + .4rem);min-width:260px;display:none;padding:10px;background:#fff;border:1px solid #eee;border-radius:12px;box-shadow:0 12px 32px rgba(0,0,0,.12)
-  }
-  .has-dropdown.open .dropdown{display:flex}
   .hero .hero-content{padding:86px 20px 64px}
   .dance-class{grid-template-columns:1fr 1fr;align-items:center}
   .instructor-grid{grid-template-columns:repeat(4,minmax(0,1fr))}
@@ -1064,7 +956,13 @@ img{max-width:100%;height:auto;border-radius:12px;display:block}
   *{animation:none !important;transition:none !important}
 }
 /* Authoritative dropdown styles (last wins) */
-@media (min-width: 921px) {
+@media (min-width: 720px) {
+    .topbar .menu > li > a,
+    .topbar .dropdown-toggle {
+        color: #111;
+        font-weight: 600;
+    }
+
     .topbar .has-dropdown {
         position: relative;
     }
@@ -1075,18 +973,28 @@ img{max-width:100%;height:auto;border-radius:12px;display:block}
             top: 100%;
             margin-top: .4rem;
             min-width: 250px;
-            background: #231c2e;
-            border: 1px solid rgba(255,255,255,.1);
+            background: #fff;
+            border: 1px solid rgba(0,0,0,.1);
             border-radius: .75rem;
             box-shadow: 0 18px 40px rgba(0,0,0,.35);
             padding: .5rem;
             z-index: 2000;
+            display: block;
             /* animated show/hide */
             opacity: 0;
             visibility: hidden;
             transform: translateY(4px);
             pointer-events: none;
             transition: opacity .18s ease, transform .18s ease, visibility 0s linear .18s;
+        }
+
+        .topbar .has-dropdown > .dropdown::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            right: 0;
+            top: -10px;
+            height: 10px;
         }
 
         .topbar .has-dropdown.open > .dropdown {
@@ -1098,16 +1006,17 @@ img{max-width:100%;height:auto;border-radius:12px;display:block}
         }
 
         .topbar .has-dropdown > .dropdown a {
-            color: #fff;
+            color: #111;
+            text-decoration: none;
         }
 
             .topbar .has-dropdown > .dropdown a:hover {
-                background: rgba(255,255,255,.08);
+                background: rgba(0,0,0,.05);
             }
 }
 
 /* Mobile: inline list when parent .open (keep light look) */
-@media (max-width: 920px) {
+@media (max-width: 719px) {
     .topbar .has-dropdown > .dropdown {
         position: static;
         margin: 0;
@@ -1120,5 +1029,19 @@ img{max-width:100%;height:auto;border-radius:12px;display:block}
         pointer-events: auto;
         padding: 0;
     }
+
+    .topbar .has-dropdown .dropdown a {
+        color: #222;
+    }
+}
+
+/* Chevron indicator */
+.topbar .dropdown-toggle .chevron {
+    margin-left: .25rem;
+    transition: transform .2s ease;
+}
+
+.topbar .has-dropdown.open .dropdown-toggle .chevron {
+    transform: rotate(180deg);
 }
 


### PR DESCRIPTION
## Summary
- Use a 720px breakpoint so the "Other Dance & Movement" dropdown overlays the page on laptops
- Switch dropdown panel to white with dark text for better contrast
- Sync JavaScript hover logic with the new 720px desktop threshold

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3baf38d6883309a34f8d7c94c7286