### PR TITLE
Add mobile sidebar navigation with accordion

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,12 +46,50 @@
     <div class="topbar" role="navigation" aria-label="Primary">
         <div class="topbar-inner">
             <a class="brand-mini" href="/" aria-label="Miss Kim's Dance Class Home">Miss Kim’s</a>
-            <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-menu">Menu</button>
+            <button class="hamburger" type="button" aria-expanded="false" aria-label="Menu">Menu</button>
+
+            <!-- Sidebar Menu (Mobile + iPad only) -->
+            <nav id="mobile-menu" class="sidebar-menu" role="navigation" aria-label="Mobile Menu">
+              <ul>
+                <li><a href="/">Home</a></li>
+
+                <li class="has-dropdown">
+                  <button class="dropdown-toggle" type="button" aria-expanded="false">
+                    Other Dance &amp; Movement <span class="chevron">▾</span>
+                  </button>
+                  <ul class="dropdown">
+                    <li><a href="/pom-poms-classes">Pom-Poms</a></li>
+                    <li><a href="/contemporary-dance-classes">Contemporary Dance</a></li>
+                    <li><a href="/hip-hop-dance-classes">Hip-Hop Dance</a></li>
+                    <li><a href="/musical-theater-classes">Musical Theater</a></li>
+                    <li><a href="/lyrical-dance-classes">Lyrical Dance</a></li>
+                    <li><a href="/tumbling-classes">Tumbling</a></li>
+                    <li><a href="/acrobatics-classes">Acrobatics</a></li>
+                    <li><a href="/aerial-classes">Aerial</a></li>
+                    <li><a href="/competition-teams">Competition</a></li>
+                    <li><a href="/ballet-dance-classes">Ballet</a></li>
+                    <li><a href="/jazz-dance-classes">Jazz</a></li>
+                    <li><a href="/tap-dance-classes">Tap</a></li>
+                  </ul>
+                </li>
+
+                <li><a href="#reviews">Reviews</a></li>
+                <li><a href="/summer">Summer</a></li>
+                <li><a href="/pricing">Pricing</a></li>
+                <li><a href="/schedule">Schedule</a></li>
+                <li><a class="btn btn--primary" href="/registration">Registration Form</a></li>
+                <li><a class="btn btn--ghost btn--sm" href="tel:+13145420608">Call (314) 542-0608</a></li>
+              </ul>
+            </nav>
+
+            <!-- Overlay -->
+            <div class="menu-overlay"></div>
+
             <ul id="primary-menu" class="menu" role="menubar">
                 <li role="none"><a role="menuitem" href="/">Home</a></li>
                 <li role="none" class="has-dropdown">
                     <button class="dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">Other Dance &amp; Movement <span class="chevron" aria-hidden="true">▾</span></button>
-                    <ul class="dropdown" role="menu" aria-label="Other Dance & Movement">
+                    <ul class="dropdown" role="menu" aria-label="Other Dance &amp; Movement">
                         <li role="none"><a role="menuitem" href="/pom-poms-classes">Pom-Poms</a></li>
                         <li role="none"><a role="menuitem" href="/contemporary-dance-classes">Contemporary Dance</a></li>
                         <li role="none"><a role="menuitem" href="/hip-hop-dance-classes">Hip-Hop Dance</a></li>
@@ -77,7 +115,6 @@
                     <a role="menuitem" class="btn btn--ghost btn--sm" href="tel:+13145420608">Call (314) 542-0608</a>
                 </li>
             </ul>
-            <div class="menu-overlay"></div>
         </div>
     </div>
 
@@ -278,39 +315,11 @@
             const $ = (sel, root = document) => root.querySelector(sel);
             const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
 
-            const navToggle = $(".nav-toggle");
-            const menu = $("#primary-menu");
-
-            // ----- Mobile Sidebar Overlay -----
-            let overlay;
-            if (menu) {
-                overlay = document.createElement("div");
-                overlay.className = "menu-overlay";
-                document.body.appendChild(overlay);
-            }
-
-            // ----- Mobile menu toggle -----
-            if (navToggle && menu) {
-                navToggle.addEventListener("click", () => {
-                    const open = menu.classList.toggle("open");
-                    navToggle.setAttribute("aria-expanded", String(open));
-                    if (overlay) overlay.classList.toggle("active", open);
-                }, { passive: true });
-            }
-
-            if (overlay) {
-                overlay.addEventListener("click", () => {
-                    menu.classList.remove("open");
-                    navToggle?.setAttribute("aria-expanded", "false");
-                    overlay.classList.remove("active");
-                });
-            }
-
             const isDesktop = () => matchMedia("(min-width: 720px)").matches;
 
-            // ----- Dropdowns -----
+            // ----- Dropdowns (desktop menu only) -----
             let ddCounter = 0;
-            const parents = $$(".has-dropdown");
+            const parents = $$(".menu > .has-dropdown");
             parents.forEach(parent => {
                 const btn = $(".dropdown-toggle", parent);
                 const panel = $(".dropdown", parent);
@@ -389,6 +398,59 @@
                 if (e.key === "Tab") document.body.classList.add("user-is-tabbing");
             }, { passive: true });
         })();
+    </script>
+
+    <script>
+    (() => {
+      const hamburger = document.querySelector('.hamburger');
+      const sidebar   = document.querySelector('.sidebar-menu');
+      const overlay   = document.querySelector('.menu-overlay');
+
+      // Toggle sidebar
+      hamburger.addEventListener('click', () => {
+        const open = sidebar.classList.toggle('open');
+        overlay.classList.toggle('active', open);
+        hamburger.setAttribute('aria-expanded', open);
+      });
+
+      // Close when overlay clicked
+      overlay.addEventListener('click', () => {
+        sidebar.classList.remove('open');
+        overlay.classList.remove('active');
+        hamburger.setAttribute('aria-expanded', false);
+      });
+
+      // Accordion dropdowns with slide animation
+      const dropdownToggles = sidebar.querySelectorAll('.dropdown-toggle');
+      dropdownToggles.forEach(btn => {
+        const parent = btn.closest('.has-dropdown');
+        const submenu = parent.querySelector('.dropdown');
+
+        // start collapsed
+        submenu.style.maxHeight = '0';
+
+        btn.addEventListener('click', e => {
+          e.preventDefault();
+          const isOpen = parent.classList.contains('open');
+
+          // close all dropdowns
+          sidebar.querySelectorAll('.has-dropdown').forEach(p => {
+            p.classList.remove('open');
+            const sm = p.querySelector('.dropdown');
+            if (sm) sm.style.maxHeight = '0';
+            const toggle = p.querySelector('.dropdown-toggle');
+            if (toggle) toggle.setAttribute('aria-expanded', 'false');
+          });
+
+          // open current one
+          if (!isOpen) {
+            parent.classList.add('open');
+            submenu.style.maxHeight = submenu.scrollHeight + 'px';
+            btn.setAttribute('aria-expanded', 'true');
+          }
+        });
+      });
+    })();
     </script>
 
 

--- a/styles.css
+++ b/styles.css
@@ -119,7 +119,7 @@ p { /* paragraph styles */
     letter-spacing: .2px /* subtle tracking */
 }
 
-.nav-toggle { /* mobile menu toggle button */
+.hamburger { /* mobile menu toggle button */
     margin-left: auto; /* push to right */
     display: none; /* hidden on desktop */
     border: 1px solid rgba(0,0,0,.2); /* subtle border on light bg */
@@ -176,26 +176,74 @@ p { /* paragraph styles */
     }
 /* Mobile nav */
 
-@media (max-width:920px) { /* styles for screens <= 920px */
-    .nav-toggle {
+@media (max-width:1024px) { /* styles for screens <= 1024px */
+    .hamburger {
         display: inline-block /* show mobile menu toggle */
     }
 
     .menu {
-        display: none; /* hide menu initially */
+        display: none; /* hide menu on mobile */
         flex-direction: column; /* vertical list */
         align-items: flex-start; /* left align */
         width: 100% /* full width */
     }
 
-        .menu.open {
-            display: flex /* show when toggled */
-        }
-
     .menu-right {
         margin-left: 0 /* reset right push */
     }
 
+    .sidebar-menu {
+        position: fixed;
+        top: 0;
+        left: -280px;
+        width: 260px;
+        height: 100%;
+        background: #fff;
+        box-shadow: 2px 0 12px rgba(0,0,0,.15);
+        padding: 60px 20px 20px;
+        transition: left .3s ease;
+        z-index: 2000;
+        overflow-y: auto;
+    }
+    .sidebar-menu.open { left: 0; }
+    .sidebar-menu a,
+    .sidebar-menu .dropdown-toggle {
+        display: block;
+        width: 100%;
+        padding: 12px 8px;
+        font-weight: 600;
+        color: #222;
+        text-decoration: none;
+        border-radius: 6px;
+    }
+    .sidebar-menu a:hover,
+    .sidebar-menu .dropdown-toggle:hover { background: #f3f3f9; }
+
+    .menu-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0,0,0,.4);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity .3s ease;
+        z-index: 1500;
+    }
+    .menu-overlay.active {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    .sidebar-menu .dropdown {
+        padding-left: 10px;
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height .3s ease;
+    }
+
+}
+
+@media (min-width:1025px) {
+    .hamburger, .sidebar-menu, .menu-overlay { display: none !important; }
 }
 /* ===================== Header ===================== */
 
@@ -852,7 +900,7 @@ img{max-width:100%;height:auto;border-radius:12px;display:block}
 .topbar{position:sticky;top:0;z-index:1000;background:rgba(255,255,255,.9);
   border-bottom:1px solid #eee;backdrop-filter:saturate(180%) blur(8px);}
 .topbar-inner{padding:12px var(--pad);gap:10px}
-.nav-toggle{padding:12px 14px;min-height:44px;border-radius:10px}
+.hamburger{padding:12px 14px;min-height:44px;border-radius:10px}
 
 /* Mobile menu as bottom sheet */
 .menu{
@@ -927,8 +975,8 @@ img{max-width:100%;height:auto;border-radius:12px;display:block}
 .footer-meta{padding:16px 0 24px;color:#555;text-align:center;font-size:.95rem}
 
 /* Desktop enhancements (keeps your existing layout) */
-@media (min-width:720px){
-  .nav-toggle{display:none}
+@media (min-width:1025px){
+  .hamburger,.sidebar-menu,.menu-overlay{display:none}
   .menu{position:static;display:flex;flex-direction:row;align-items:center;gap:10px;padding:0;background:transparent;border:0;box-shadow:none;max-height:none;border-radius:0;overflow:visible}
   .menu a,.menu .dropdown-toggle{background:transparent;border:0;padding:10px 12px}
   .menu a:hover,.menu .dropdown-toggle:hover{background:#f5f3ff}
@@ -1148,23 +1196,5 @@ li {
             .menu a:hover,
             .menu .dropdown-toggle:hover {
                 background: #f5f5f9;
-            }
-
-    /* optional overlay behind sidebar */
-    .menu-overlay {
-        content: "";
-        position: fixed;
-        inset: 0;
-        background: rgba(0,0,0,.4);
-        opacity: 0;
-        pointer-events: none;
-        transition: opacity .3s ease;
-        z-index: 1500;
-    }
-
-    .menu.open + .menu-overlay {
-        opacity: 1;
-        pointer-events: auto;
-    }
 }
 


### PR DESCRIPTION
## Summary
- add hamburger-driven sidebar menu for mobile with overlay and accordion dropdown
- update styles to show desktop menu while providing mobile-only sidebar
- clean up navigation script for desktop dropdowns and add mobile toggle logic
- add slide animation for mobile accordion dropdowns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d6e8a8748330998c4c5b821f2637