### PR TITLE
Remove free trial references, refresh imagery, and fix mobile layout

### DIFF
--- a/acrobatics-classes.html
+++ b/acrobatics-classes.html
@@ -19,7 +19,7 @@
     <meta property="og:title" content="Acrobatics Classes — Miss Kim’s Dance Class" />
     <meta property="og:description" content="Balance · Agility · Flexibility. Small group acrobatics instruction with experienced teachers." />
     <meta property="og:url" content="https://www.misskimsdanceclass.com/acrobatics-classes" />
-    <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/tumbling.jpg" />
+    <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/IMG_9826.JPG" />
 
     <!-- Styles -->
     <link rel="stylesheet" href="/styles.css" />
@@ -153,7 +153,7 @@
     <main id="main">
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/tumbling.jpg')"></div>
+            <div class="hero-background" style="background-image:url('/photos/IMG_9826.JPG')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Acrobatics at Miss Kim’s</h1>
                 <p class="hero-tagline">Balance · Agility · Flexibility</p>
@@ -174,9 +174,8 @@
 
                 <p class="cta-inline">
                     <a class="btn btn--primary" href="/schedule">See Schedule</a>
-                    <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                    <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
-                </p>
+                <a class="btn btn--ghost" href="/pricing">Pricing</a>
+            </p>
             </div>
         </section>
     </main>

--- a/aerial-classes.html
+++ b/aerial-classes.html
@@ -19,7 +19,7 @@
     <meta property="og:title" content="Aerial Dance Classes — Miss Kim’s Dance Class" />
     <meta property="og:description" content="Strength · Lines · Control. Small group aerial instruction in Chesterfield, MO." />
     <meta property="og:url" content="https://www.misskimsdanceclass.com/aerial-classes" />
-    <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/lyrical1.jpg" />
+    <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/2-PMR_4687.jpg" />
 
     <!-- Site Theme -->
     <link rel="stylesheet" href="/styles.css" />
@@ -153,7 +153,7 @@
     <main id="main">
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/lyrical1.jpg')"></div>
+            <div class="hero-background" style="background-image:url('/photos/2-PMR_4687.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Aerial Classes in Chesterfield, MO</h1>
                 <p class="hero-tagline">Strength · Lines · Control</p>
@@ -174,9 +174,8 @@
 
                 <p class="cta-inline">
                     <a class="btn btn--primary" href="/schedule">See Schedule</a>
-                    <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                    <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
-                </p>
+                <a class="btn btn--ghost" href="/pricing">Pricing</a>
+            </p>
             </div>
         </section>
     </main>

--- a/ballet-dance-classes.html
+++ b/ballet-dance-classes.html
@@ -19,7 +19,7 @@
     <meta property="og:title" content="Ballet Dance Classes — Miss Kim’s Dance Class" />
     <meta property="og:description" content="Classic technique, graceful movement, and a strong foundation for all dancers." />
     <meta property="og:url" content="https://www.misskimsdanceclass.com/ballet-dance-classes" />
-    <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/ballet.jpg" />
+    <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/Pointe1.jpg" />
 
     <!-- Theme CSS -->
     <link rel="stylesheet" href="/styles.css" />
@@ -151,7 +151,7 @@
     <main id="main">
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/ballet.jpg')"></div>
+            <div class="hero-background" style="background-image:url('/photos/Pointe1.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Ballet Dance Classes</h1>
                 <p>Classic technique, graceful movement, and strong foundation for all dancers.</p>
@@ -176,7 +176,6 @@
             <p class="cta-inline">
                 <a class="btn btn--primary" href="/schedule">See Schedule</a>
                 <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
             </p>
         </section>
     </main>

--- a/contemporary-dance-classes.html
+++ b/contemporary-dance-classes.html
@@ -10,7 +10,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Contemporary Dance Classes | Miss Kim’s Dance Class — Chesterfield, MO</title>
-    <meta name="description" content="Contemporary classes blending modern technique with musicality—breath, momentum, floorwork, and expressive choreography. Small classes, free trial." />
+    <meta name="description" content="Contemporary classes blending modern technique with musicality—breath, momentum, floorwork, and expressive choreography." />
     <link rel="canonical" href="https://www.misskimsdanceclass.com/contemporary-dance-classes" />
     <meta name="theme-color" content="#5f35b0" />
 
@@ -171,7 +171,6 @@
             <p class="cta-inline">
                 <a class="btn btn--primary" href="/schedule">See Schedule</a>
                 <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
             </p>
         </section>
     </main>

--- a/hip-hop-dance-classes.html
+++ b/hip-hop-dance-classes.html
@@ -10,7 +10,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Hip-Hop Dance Classes | Miss Kim’s Dance Class — Chesterfield, MO</title>
-    <meta name="description" content="Age-appropriate hip-hop training: grooves, isolations, combos, and freestyle in a positive, high-energy class. Free trial." />
+    <meta name="description" content="Age-appropriate hip-hop training: grooves, isolations, combos, and freestyle in a positive, high-energy class." />
     <link rel="canonical" href="https://www.misskimsdanceclass.com/hip-hop-dance-classes" />
     <meta name="theme-color" content="#5f35b0" />
 
@@ -171,7 +171,6 @@
             <p class="cta-inline">
                 <a class="btn btn--primary" href="/schedule">See Schedule</a>
                 <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
             </p>
         </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <!-- Meta & SEO -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Miss Kim's Dance Class in Chesterfield, MO — ballet, jazz, hip-hop, contemporary, pom-poms, musical theater, tumbling, acrobatics, aerial, competition teams. Free trial, fair pricing, small classes since 1994." />
+    <meta name="description" content="Miss Kim's Dance Class in Chesterfield, MO — ballet, jazz, hip-hop, contemporary, pom-poms, musical theater, tumbling, acrobatics, aerial, competition teams. Fair pricing, small classes since 1994." />
     <meta name="keywords" content="dance classes, contemporary dance, ballet, jazz, hip hop, Chesterfield" />
     <meta name="robots" content="index, follow, max-image-preview:large" />
     <link rel="canonical" href="https://www.misskimsdanceclass.com/" />
@@ -17,7 +17,7 @@
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Miss Kim's Dance Class — Chesterfield, MO" />
-    <meta property="og:description" content="Free trial class · Fair pricing · Small classes · Since 1994. Register today." />
+    <meta property="og:description" content="Fair pricing · Small classes · Since 1994. Register today." />
     <meta property="og:url" content="https://www.misskimsdanceclass.com/" />
     <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/contemporary1.JPG" />
     <meta property="og:image:width" content="1200" />
@@ -140,7 +140,7 @@
             <!-- Tap -->
             <section id="tap-dance" class="dance-class">
                 <div class="dance-image">
-                    <img src="/photos/tap1.JPG" width="560" height="360" alt="Tap dance class in Chesterfield, MO for all ages" loading="lazy" decoding="async">
+                    <img src="/photos/tap3.JPG" width="560" height="360" alt="Tap dance class in Chesterfield, MO for all ages" loading="lazy" decoding="async">
                 </div>
                 <div class="dance-info">
                     <h3>Tap Dance Classes in Chesterfield, MO</h3>
@@ -152,7 +152,7 @@
             <!-- Ballet -->
             <section id="ballet-dance" class="dance-class">
                 <div class="dance-image">
-                    <img src="/photos/tap9.JPG" width="560" height="360" alt="Ballet dance lessons in Chesterfield, Missouri" loading="lazy" decoding="async">
+                    <img src="/photos/Pointe1.jpg" width="560" height="360" alt="Ballet dance lessons in Chesterfield, Missouri" loading="lazy" decoding="async">
                 </div>
                 <div class="dance-info">
                     <h3>Ballet Dance Lessons in Chesterfield, MO</h3>
@@ -250,8 +250,8 @@
                 </div>
                 <p class="cta-inline">
                     <a class="btn btn--primary" href="/reviews">Read More Reviews</a>
-                    <a class="btn btn--ghost" href="https://g.page/r/YourGoogleReviewLink" rel="noopener nofollow" target="_blank">Write a Google Review</a>
-                    <a class="btn btn--ghost" href="https://www.facebook.com/yourpage/reviews/" rel="noopener nofollow" target="_blank">Write a Facebook Review</a>
+                    <a class="btn btn--ghost" href="https://www.google.com/search?sca_esv=5d812c3a7137edf1&amp;rlz=1C1GCEA_enUS1168US1168&amp;sxsrf=AE3TifPF1iAdM6TCJFkR90-FX1HYKv4rIA:1756770997257&amp;si=AMgyJEuzsz2NflaaWzrzdpjxXXRaJ2hfdMsbe_mSWso6src8s9zK2D9jlcLVun5nozonrTe9tOTteMAIcDD9xh6D8ztyo7vfUb957P6rJcSkKEFkNfed_3gdQRxy0PVa1fVHBQRbsQxVmutkDUjXs-1NwAxt2NUqwA%3D%3D&amp;q=Miss+Kim%27s+Dance+Class+Reviews&amp;sa=X&amp;ved=2ahUKEwji7fj54biPAxVKmokEHUjtHDAQ0bkNegQIIhAE&amp;biw=1536&amp;bih=730&amp;dpr=1.25" rel="noopener nofollow" target="_blank">Write a Google Review</a>
+                    <a class="btn btn--ghost" href="https://www.facebook.com/misskimsdanceclass/" rel="noopener nofollow" target="_blank">Write a Facebook Review</a>
                 </p>
             </div>
         </section>
@@ -305,7 +305,6 @@
                   "@context":"https://schema.org",
                   "@type":"FAQPage",
                   "mainEntity":[
-                    {"@type":"Question","name":"Do you offer a free trial dance class?","acceptedAnswer":{"@type":"Answer","text":"Yes, you can book a free trial to try any beginner class."}},
                     {"@type":"Question","name":"What ages do you teach?","acceptedAnswer":{"@type":"Answer","text":"We offer classes for kids, teens, and adults with multiple levels."}}
                   ]
                 }

--- a/jazz-dance-classes.html
+++ b/jazz-dance-classes.html
@@ -17,7 +17,7 @@
     <!-- OG -->
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Jazz Dance Classes — Miss Kim’s Dance Class" />
-    <meta property="og:description" content="High-energy jazz classes blending technique, rhythm, and expression. Small classes, free trial available." />
+    <meta property="og:description" content="High-energy jazz classes blending technique, rhythm, and expression." />
     <meta property="og:url" content="https://www.misskimsdanceclass.com/jazz-dance-classes" />
     <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/jazz1.JPG" />
 
@@ -175,7 +175,6 @@
             <p class="cta-inline">
                 <a class="btn btn--primary" href="/schedule">See Schedule</a>
                 <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
             </p>
         </section>
     </main>

--- a/lyrical-dance-classes.html
+++ b/lyrical-dance-classes.html
@@ -170,7 +170,6 @@
             <p class="cta-inline">
                 <a class="btn btn--primary" href="/schedule">See Schedule</a>
                 <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
             </p>
         </section>
     </main>

--- a/musical-theater-classes.html
+++ b/musical-theater-classes.html
@@ -171,7 +171,6 @@
             <p class="cta-inline">
                 <a class="btn btn--primary" href="/schedule">See Schedule</a>
                 <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
             </p>
         </section>
     </main>

--- a/pom-poms-classes.html
+++ b/pom-poms-classes.html
@@ -10,7 +10,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Pom-Poms Dance Classes | Miss Kim’s Dance Class — Chesterfield, MO</title>
-    <meta name="description" content="High-energy pom-pom dance classes that blend cheer style with sharp, rhythmic choreography. Small classes, fair pricing, free trial." />
+    <meta name="description" content="High-energy pom-pom dance classes that blend cheer style with sharp, rhythmic choreography. Small classes and fair pricing." />
     <link rel="canonical" href="https://www.misskimsdanceclass.com/pom-poms-classes" />
     <meta name="theme-color" content="#5f35b0" />
 
@@ -179,7 +179,6 @@
             <p class="cta-inline">
                 <a class="btn btn--primary" href="/schedule">See Schedule</a>
                 <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
             </p>
         </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -533,9 +533,6 @@ nav.menu { /* mobile slide-out menu */
     align-items: center /* vertically align */
 }
 
-    .dance-class:nth-child(even) .dance-image { /* alternate layout for even rows */
-        order: 2 /* place image second */
-    }
 
 .dance-image img { /* class image styling */
     width: 100%; /* responsive width */
@@ -661,9 +658,10 @@ nav.menu { /* mobile slide-out menu */
     }
 /* ===================== Reviews ===================== */
 
+
 .reviews { /* reviews section with bg image */
-    background: url('/images/reviews-bg.webp') center/cover no-repeat fixed, linear-gradient(#0003,#0003); /* parallax-like bg with overlay */
-    color: #fff; /* white text */
+    background: linear-gradient(#fff,#fff), url('/images/reviews-bg.webp') center/cover no-repeat fixed; /* light bg with image */
+    color: #000; /* black text */
     margin: 0; /* reset margins */
     margin-inline: calc(50% - 50vw); /* full-bleed width */
     width: 100vw /* full viewport width */
@@ -677,7 +675,7 @@ nav.menu { /* mobile slide-out menu */
         text-align: center; /* center title */
         margin-bottom: 1rem; /* space below */
         font-size: clamp(1.5rem,2.2vw,2rem); /* responsive size */
-        color: #fff /* keep white on dark */
+        color: #000 /* black heading */
     }
 
 .reviews-embeds { /* grid for embedded reviews widgets */
@@ -701,7 +699,7 @@ nav.menu { /* mobile slide-out menu */
 }
 
 .review { /* individual review card */
-    background: rgba(0,0,0,.5); /* translucent dark card */
+    background: #fff; /* light card for black text */
     border-radius: 12px; /* rounded corners */
     padding: 1rem; /* inner spacing */
     box-shadow: 0 6px 24px rgba(0,0,0,.12) /* soft shadow */
@@ -1520,6 +1518,7 @@ img, video, iframe, picture {
 @media (min-width: 720px) {
     :root { --site-max-width: 1120px; }
     .dance-class { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .dance-class:nth-child(even) .dance-image { order: 2; }
     .instructor-grid { grid-template-columns: repeat(4, 1fr); }
     .review-list { grid-template-columns: repeat(3, 1fr); }
 }
@@ -1530,7 +1529,6 @@ img, video, iframe, picture {
     .container { padding-inline: clamp(16px, 2vw, 48px); }
 }
 
-}
 /* Tiny safety: remove any leftover element forced to 100vw which causes horizontal scroll */
 *:where([style*="width:100vw"], [style*="width:100%vw"]) {
     max-width: 100%;

--- a/tap-dance-classes.html
+++ b/tap-dance-classes.html
@@ -19,7 +19,7 @@
     <meta property="og:title" content="Tap Dance Classes — Miss Kim’s Dance Class" />
     <meta property="og:description" content="Step into rhythm with upbeat tap dance lessons that build timing, musicality, and performance confidence." />
     <meta property="og:url" content="https://www.misskimsdanceclass.com/tap-dance-classes" />
-    <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/tap1.JPG" />
+    <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/tap3.JPG" />
 
     <!-- Theme CSS -->
     <link rel="stylesheet" href="/styles.css" />
@@ -150,7 +150,7 @@
     <main id="main">
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/tap1.JPG')"></div>
+            <div class="hero-background" style="background-image:url('/photos/tap3.JPG')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Tap Dance Classes</h1>
                 <p>Step into rhythm with engaging, upbeat tap dance lessons.</p>
@@ -175,7 +175,6 @@
             <p class="cta-inline">
                 <a class="btn btn--primary" href="/schedule">See Schedule</a>
                 <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
             </p>
         </section>
     </main>

--- a/tumbling-classes.html
+++ b/tumbling-classes.html
@@ -177,7 +177,6 @@
             <p class="cta-inline">
                 <a class="btn btn--primary" href="/schedule">See Schedule</a>
                 <a class="btn btn--ghost" href="/pricing">Pricing</a>
-                <a class="btn btn--ghost" href="/free-trial">Free Trial</a>
             </p>
         </section>
     </main>


### PR DESCRIPTION
## Summary
- remove all "Free Trial" mentions and buttons across pages
- add real Google and Facebook review links and switch review section text to black
- swap home page and class images to show dancers' faces and correct styles
- fix mobile class layout by only alternating images on larger screens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6345cdc548330b2f0bd0ae98c98d8