### PR TITLE
Add SEO metadata and crawl directives

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
     <meta name="keywords" content="dance classes, contemporary dance, ballet, jazz, hip hop, Chesterfield" />
     <meta name="robots" content="index, follow, max-image-preview:large" />
     <link rel="canonical" href="https://www.misskimsdanceclass.com/" />
+    <meta name="author" content="Miss Kim's Dance Class" />
+    <meta property="og:locale" content="en_US" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
@@ -22,6 +24,11 @@
     <meta property="og:image" content="https://www.misskimsdanceclass.com/photos/contemporary1.JPG" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:site_name" content="Miss Kim's Dance Class" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Miss Kim's Dance Class — Chesterfield, MO" />
+    <meta name="twitter:description" content="Fair pricing · Small classes · Since 1994. Register today." />
+    <meta name="twitter:image" content="https://www.misskimsdanceclass.com/photos/contemporary1.JPG" />
     <!-- Favicons -->
     <meta name="theme-color" content="#5f35b0" />
     <link rel="icon" href="/favicon.ico" />
@@ -38,6 +45,25 @@
     <!-- Defer scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js" defer></script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "DanceSchool",
+      "name": "Miss Kim's Dance Class",
+      "url": "https://www.misskimsdanceclass.com/",
+      "image": "https://www.misskimsdanceclass.com/photos/contemporary1.JPG",
+      "telephone": "+1-314-542-0608",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "14278 Ladue Rd",
+        "addressLocality": "Chesterfield",
+        "addressRegion": "MO",
+        "postalCode": "63017",
+        "addressCountry": "US"
+      },
+      "sameAs": ["https://www.facebook.com/misskimsdanceclass"]
+    }
+    </script>
 </head>
 <body id="dmRoot" class="dmRoot dmResponsiveBody">
     <!-- Skip Link -->

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://www.misskimsdanceclass.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://www.misskimsdanceclass.com/</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/pricing</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/schedule</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/registration</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/summer</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/acrobatics-classes</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/aerial-classes</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/ballet-dance-classes</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/competition-teams</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/contemporary-dance-classes</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/hip-hop-dance-classes</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/jazz-dance-classes</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/lyrical-dance-classes</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/musical-theater-classes</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/pom-poms-classes</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/tap-dance-classes</loc></url>
+  <url><loc>https://www.misskimsdanceclass.com/tumbling-classes</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- enhance homepage with author, locale, Twitter metadata and structured LocalBusiness JSON‑LD
- add sitemap.xml listing key class and info pages
- provide robots.txt referencing the sitemap and allowing crawling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b64125c8ac83308a6cf27520de22c9