### PR TITLE
Use shared hero banner image across pages

### DIFF
--- a/acrobatics-classes.html
+++ b/acrobatics-classes.html
@@ -160,7 +160,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/IMG_9826.JPG')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Acrobatics at Miss Kim’s</h1>
                 <p class="hero-tagline">Balance · Agility · Flexibility</p>

--- a/aerial-classes.html
+++ b/aerial-classes.html
@@ -160,7 +160,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/2-PMR_4687.jpg')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Aerial Classes in Chesterfield, MO</h1>
                 <p class="hero-tagline">Strength · Lines · Control</p>

--- a/ballet-dance-classes.html
+++ b/ballet-dance-classes.html
@@ -158,7 +158,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/Pointe1.jpg')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Ballet Dance Classes</h1>
                 <p>Classic technique, graceful movement, and strong foundation for all dancers.</p>

--- a/competition-teams.html
+++ b/competition-teams.html
@@ -161,7 +161,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/Competition3.JPG')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Competition Team (Chesterfield, MO)</h1>
                 <p class="hero-tagline">Growth · Teamwork · Performance</p>

--- a/contemporary-dance-classes.html
+++ b/contemporary-dance-classes.html
@@ -157,7 +157,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/contemporary1.JPG')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Contemporary Dance in Chesterfield, MO</h1>
                 <p class="hero-tagline">Breath · Momentum · Level changes & floorwork</p>

--- a/hip-hop-dance-classes.html
+++ b/hip-hop-dance-classes.html
@@ -157,7 +157,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/Hiphop1.JPG')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Hip-Hop Dance in Chesterfield, MO</h1>
                 <p class="hero-tagline">Groove · Musicality · Confidence</p>

--- a/jazz-dance-classes.html
+++ b/jazz-dance-classes.html
@@ -157,7 +157,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/jazz1.JPG')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Jazz Dance Classes</h1>
                 <p>High-energy dance lessons blending technique, rhythm, and expression.</p>

--- a/lyrical-dance-classes.html
+++ b/lyrical-dance-classes.html
@@ -157,7 +157,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/lyrical1.jpg')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Lyrical Dance in Chesterfield, MO</h1>
                 <p class="hero-tagline">Lines · Flow · Expression</p>

--- a/musical-theater-classes.html
+++ b/musical-theater-classes.html
@@ -157,7 +157,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/musicaltheatre.JPG')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Musical Theater in Chesterfield, MO</h1>
                 <p class="hero-tagline">Stage presence · Audition skills · Storytelling</p>

--- a/pom-poms-classes.html
+++ b/pom-poms-classes.html
@@ -158,7 +158,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/pompom.jpg')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Pom-Poms Dance in Chesterfield, MO</h1>
                 <p class="hero-tagline">Sharp motions · Formations · Team spirit</p>

--- a/reviews.html
+++ b/reviews.html
@@ -65,7 +65,7 @@
         </nav>
 
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/contemporary1.JPG')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Reviews</h1>
                 <p class="hero-tagline">What Families Are Saying</p>

--- a/styles.css
+++ b/styles.css
@@ -864,15 +864,15 @@ nav.menu { /* mobile slide-out menu */
 }
 
 .hero-background.jazz { /* hero variant for Jazz page */
-    background: url('/photos/jazz1.JPG') center/cover no-repeat; /* jazz image */
+    background: url('/photos/herobanner.jpg') center/cover no-repeat; /* jazz image */
 }
 
 .hero-background.ballet { /* hero variant for Ballet page */
-    background: url('/images/tap6.JPG') center/cover no-repeat; /* ballet image */
+    background: url('/photos/herobanner.jpg') center/cover no-repeat; /* ballet image */
 }
 
 .hero-background.tap { /* hero variant for Tap page */
-    background: url('/images/tap1.JPG') center/cover no-repeat; /* tap image */
+    background: url('/photos/herobanner.jpg') center/cover no-repeat; /* tap image */
 }
 /* ========= Mobile polish pack (append at end) ========= */
 :root {

--- a/tap-dance-classes.html
+++ b/tap-dance-classes.html
@@ -157,7 +157,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/tap3.JPG')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Tap Dance Classes</h1>
                 <p>Step into rhythm with engaging, upbeat tap dance lessons.</p>

--- a/tumbling-classes.html
+++ b/tumbling-classes.html
@@ -157,7 +157,7 @@
 
         <!-- Hero -->
         <section class="hero" aria-labelledby="hero-title">
-            <div class="hero-background" style="background-image:url('/photos/tumbling.jpg')"></div>
+            <div class="hero-background" style="background-image:url('/photos/herobanner.jpg')"></div>
             <div class="hero-content">
                 <h1 id="hero-title">Tumbling at Miss Kim’s</h1>
                 <p class="hero-tagline">Strength · Flexibility · Aerial skills</p>


### PR DESCRIPTION
## Summary
- Replace page-specific hero banner images with `/photos/herobanner.jpg`
- Update CSS hero background classes to use shared image

## Testing
- `npx --yes prettier --check acrobatics-classes.html aerial-classes.html ballet-dance-classes.html competition-teams.html contemporary-dance-classes.html hip-hop-dance-classes.html jazz-dance-classes.html lyrical-dance-classes.html musical-theater-classes.html pom-poms-classes.html reviews.html tap-dance-classes.html tumbling-classes.html styles.css` *(failed: code style issues found in 14 files)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a39489a08330b45efd6cb8733cba