### PR TITLE
Adjust branding label and Gmail contact info

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
     <!-- Sticky Top Bar / Nav (desktop) -->
     <div class="topbar" role="navigation" aria-label="Primary">
         <div class="topbar-inner">
-            <a class="brand-mini" href="/" aria-label="Miss Kim's Dance Class Home">Miss Kim’s</a>
+            <a class="brand-mini" href="/" aria-label="Miss Kim's Dance Class Home">Miss Kim’s Dance Class</a>
             <ul id="#primary-menu" class="menu" role="menubar">
                 <li role="none"><a role="menuitem" href="/">Home</a></li>
                 <li role="none" class="has-dropdown">
@@ -164,7 +164,7 @@
                 <h1 id="hero-title">Miss Kim's Dance Class</h1>
                 <h1 id="hero-description">Dance Instruction in Chesterfield, MO</h1>
                 <a href="tel:+13145420608" class="hero-call" aria-label="Studio landline, call (314) 542-0608">Studio Landline (Call) (314) 542-0608</a>
-                <a href="tel:+13144538688" class="hero-call" aria-label="Kim's cell, call or text (314) 453-8688">Kim’s Cell (Call or Text) (314) 453-8688</a>
+                <a href="tel:+13144538688" class="hero-call" aria-label="Kim's cellphone, call or text (314) 453-8688">Kim’s Cellphone (Call or Text) (314) 453-8688</a>
                 <a href="mailto:misskimdances@gmail.com" class="hero-call" aria-label="Email Miss Kim at misskimdances@gmail.com">Email Miss Kim (Gmail)</a>
                 <a href="/tuition" class="hero-call" aria-label="View fall tuition rates">View Fall Tuition</a>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -103,19 +103,22 @@ p { /* paragraph styles */
 }
 
 .topbar-inner { /* inner layout of topbar */
-    max-width: var(--header-maxw); /* match header width */
+    max-width: min(1400px, 100%); /* allow a little extra width before wrapping */
     margin: 0 auto; /* center */
-    padding: .5rem 1rem; /* spacing */
+    padding: .5rem clamp(10px, 1.6vw, 16px); /* responsive side padding */
     display: flex; /* flex layout */
     align-items: center; /* vertically center items */
-    gap: 1rem /* spacing between items */
+    gap: .5rem; /* keep brand and menu close without crowding */
+    flex-wrap: nowrap; /* ensure the header stays in a single row */
 }
 
 .brand-mini { /* compact brand link in nav */
     color: var(--ink-strong); /* dark text for light header */
     text-decoration: none; /* no underline */
     font-weight: 800; /* heavy weight */
-    letter-spacing: .2px /* subtle tracking */
+    letter-spacing: .2px; /* subtle tracking */
+    white-space: nowrap; /* prevent the brand from breaking to two lines */
+    flex-shrink: 0; /* keep the brand from squeezing the menu */
 }
 
 .hamburger { /* mobile menu toggle button */
@@ -188,7 +191,7 @@ nav.menu { /* mobile slide-out menu */
     padding: 0; /* reset padding */
     display: flex; /* horizontal layout */
     flex-wrap: wrap; /* wrap on small widths */
-    gap: .5rem 1rem; /* row/column gaps */
+    gap: .35rem .6rem; /* tighter row/column gaps */
     align-items: center /* vertically center links */
 }
 
@@ -198,7 +201,7 @@ nav.menu { /* mobile slide-out menu */
         background: transparent; /* transparent buttons */
         border: 0; /* no border */
         font: inherit; /* inherit font family/size */
-        padding: .5rem .45rem; /* link padding */
+        padding: .4rem .3rem; /* slightly slimmer link padding */
         border-radius: .5rem; /* rounded hover target */
         line-height: 1.2 /* tidy line height */
     }
@@ -349,6 +352,51 @@ nav.menu { /* mobile slide-out menu */
 .btn--sm { /* small button variant */
     padding: .45rem .8rem; /* smaller padding */
     font-size: .92rem /* smaller text */
+}
+
+.topbar .btn { /* slightly leaner buttons in the sticky nav */
+    padding: .4rem .65rem; /* tighter padding keeps actions on one line */
+    font-size: .9rem; /* compact nav button text */
+    white-space: nowrap; /* avoid button labels wrapping */
+}
+
+.topbar .menu { /* compact nav typography on desktop */
+    font-size: .9rem; /* smaller desktop nav type */
+    flex: 1 1 auto; /* let the menu use remaining header space */
+    flex-wrap: nowrap; /* keep nav items on a single line */
+    gap: .32rem; /* reduce the horizontal gap between items */
+    align-items: center; /* align menu items vertically */
+    min-width: 0; /* allow flexbox to shrink the list when space is tight */
+}
+
+.topbar .menu > li { /* prevent individual nav items from breaking */
+    white-space: nowrap;
+}
+
+.topbar .menu > li > a,
+.topbar .menu > li > button.dropdown-toggle { /* snug padding for desktop nav links */
+    padding: .35rem .45rem;
+}
+
+@media (max-width: 1280px) {
+    .topbar-inner { /* allow a touch more room on medium desktops */
+        padding-inline: clamp(8px, 1.4vw, 14px);
+    }
+
+    .topbar .menu { /* further tighten spacing on medium desktops */
+        font-size: .88rem;
+        gap: .28rem;
+    }
+
+    .topbar .menu > li > a,
+    .topbar .menu > li > button.dropdown-toggle {
+        padding: .32rem .4rem;
+    }
+
+    .topbar .btn {
+        padding: .35rem .55rem;
+        font-size: .88rem;
+    }
 }
 /* small variant for topbar */
 
@@ -1452,6 +1500,12 @@ body {
     margin-inline: auto;
     padding-inline: clamp(12px, 2.2vw, 28px);
     width: 100%;
+}
+
+/* Allow the sticky topbar a little extra breathing room so menu items stay on one line */
+.topbar-inner {
+    max-width: min(1400px, 100%);
+    width: min(1400px, 100%);
 }
 
 /* Neutralize previous full-bleed tricks (they cause content to stick to edges) */

--- a/tuition.html
+++ b/tuition.html
@@ -224,9 +224,9 @@
         }
     </style>
 
-    <!-- JSON-LD (kept; uses payment account email) -->
+    <!-- JSON-LD (contact email uses Gmail address) -->
     <script type="application/ld+json">
-        {"@context":"https://schema.org","@type":"DanceSchool","name":"Miss Kim’s Dance Class","url":"https://www.misskimsdanceclass.com/","logo":"https://www.misskimsdanceclass.com/logo.webp","address":{"@type":"PostalAddress","streetAddress":"14781 Ladue Rd","addressLocality":"Chesterfield","addressRegion":"MO","postalCode":"63017","addressCountry":"US"},"email":"misskimdances@yahoo.com","paymentAccepted":["Cash","Check","PayPal","Venmo"]}
+        {"@context":"https://schema.org","@type":"DanceSchool","name":"Miss Kim’s Dance Class","url":"https://www.misskimsdanceclass.com/","logo":"https://www.misskimsdanceclass.com/logo.webp","address":{"@type":"PostalAddress","streetAddress":"14781 Ladue Rd","addressLocality":"Chesterfield","addressRegion":"MO","postalCode":"63017","addressCountry":"US"},"email":"misskimdances@gmail.com","paymentAccepted":["Cash","Check","PayPal","Venmo"]}
     </script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- spell out the desktop navigation brand as "Miss Kim’s Dance Class" and clarify the hero call-to-action copy for Kim’s cellphone on the homepage
- update the tuition page JSON-LD to list the Gmail address as the studio contact while leaving Yahoo for payment processing
- tighten the sticky desktop navigation spacing so menu actions stay on a single line at medium widths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d04be29f888330b4285f94be335e54